### PR TITLE
#65 - changing the maven version to the one available in repo

### DIFF
--- a/docs/2.0/reporting/maven.adoc
+++ b/docs/2.0/reporting/maven.adoc
@@ -13,7 +13,7 @@ Add allure-maven-plugin to your pom.xml file build section.
     <plugin>
         <groupId>io.qameta.allure</groupId>
         <artifactId>allure-maven</artifactId>
-        <version>2.9</version>
+        <version>2.8</version>
     </plugin>
     ...
 </project>


### PR DESCRIPTION
Based on the https://github.com/allure-framework/allure-maven/releases link , I am assuming that the doc should have 2.8 version for allure-maven.


issue link - https://github.com/allure-framework/allure-docs/issues/65