### PR TITLE
Correcting allure.properties file example in Commandline chapter

### DIFF
--- a/docs/2.0/reporting/commandline.adoc
+++ b/docs/2.0/reporting/commandline.adoc
@@ -45,8 +45,9 @@ To configure the Allure report you should create *allure.properties* file
 [source]
 .allure.properties
 ----
-allure.issues.tracker.pattern=https://tms/testcase-%s
-allure.tests.management.pattern=https://bugtracker/issue-%s
+allure.link.mylink.pattern=https://example.org/mylink/{}
+allure.link.issue.pattern=https://example.org/issue/{}
+allure.link.tms.pattern=https://example.org/tms/{}
 ----
 
 and simply generate the report. By default command line tool looking for config in directory you run the command.


### PR DESCRIPTION
The chapter Reporting/Commandline/Configuration/Properties file contains outdated information. Trying to correct the allure.properties file content example.