### PR TITLE
Fixing word and image link on Cucumber JVM

### DIFF
--- a/docs/2.0/integration/cucumberjvm.adoc
+++ b/docs/2.0/integration/cucumberjvm.adoc
@@ -2,9 +2,9 @@
 
 == Installation
 
-The available latest version of `allure-testng`:
+The available latest version of `allure-cucumber-jvm`:
 
-image::https://img.shields.io/maven-central/v/io.qameta.allure/allure-cucumberjvm.svg[Allure CucumberJVM]
+image::https://img.shields.io/maven-central/v/io.qameta.allure/allure-cucumber-jvm.svg[Allure CucumberJVM]
 
 === Maven
 Simply add `allure-cucumber-jvm` plugin as dependency to your project and add it to CucumberOptions:


### PR DESCRIPTION
fixes #75 
Fix typo and image link on Cucumber JVM Installation paragraph