### PR TITLE
Correct TeamCity plugin installation procedure

### DIFF
--- a/docs/reporting/teamcity.adoc
+++ b/docs/reporting/teamcity.adoc
@@ -1,10 +1,10 @@
 = TeamCity
 
 == Installation
-. https://confluence.jetbrains.com/display/TCD9/Installing+Additional+Plugins[Install Allure TeamCity plugin].
+. https://confluence.jetbrains.com/display/TCD10/Installing+Additional+Plugins[Install Allure TeamCity plugin].
 . Download the latest `allure-x.x.zip` from (https://bintray.com/qameta/generic/allure2[latest release]
 . Copy downloaded file
-to the <https://confluence.jetbrains.com/display/TCD9/TeamCity+Data+Directory[TeamCity Data Directory]>/plugins/.tools directory as `allure-commandline.zip`.
+to the <https://confluence.jetbrains.com/display/TCD10/TeamCity+Data+Directory[TeamCity Data Directory]>/plugins/.tools directory as `allure-commandline.zip`.
 No server restart needed for this step.
 
 == Configuration

--- a/docs/reporting/teamcity.adoc
+++ b/docs/reporting/teamcity.adoc
@@ -2,22 +2,24 @@
 
 == Installation
 . https://confluence.jetbrains.com/display/TCD9/Installing+Additional+Plugins[Install Allure TeamCity plugin].
-. Copy the **allure.zip** from (https://bintray.com/qameta/generic/allure2[latest release]
-to the <https://confluence.jetbrains.com/display/TCD9/TeamCity+Data+Directory[TeamCity Data Directory]>/plugins/.tools directory.
+. Download the latest `allure-x.x.zip` from (https://bintray.com/qameta/generic/allure2[latest release]
+. Copy downloaded file
+to the <https://confluence.jetbrains.com/display/TCD9/TeamCity+Data+Directory[TeamCity Data Directory]>/plugins/.tools directory as `allure-commandline.zip`.
 No server restart needed for this step.
 
 == Configuration
 . Open the build **configuration settings**.
 . Ensure that your build https://github.com/allure-framework/allure-core/wiki#gathering-information-about-tests)[generates Allure XML files].
 . Go to **Build steps** and add the **Allure Report** build step.
+. (optional) In **Execute step:** select **Even if some of the previous steps failed** to generate report for failing tests as well.
 +
-image::teamcity_plugin_add_build_step.png[TeamCity Plugin Install]
+image::teamcity_plugin_add_build_step.png[TeamCity plugin add step]
 . Configure the step.
 +
-image::teamcity_plugin_configure_build_step.png[jenkins plugin install]
+image::teamcity_plugin_configure_build_step.png[TeamCity plugin install]
 
 In case you upgrading the Allure TeamCity plugin you need to remove old Allure report generation feature.
 
 == Usage
 When the build is done you will get Allure Report as a part of build artifacts – simply open the index.html.  
-image::teamcity_plugin_usage.png[jenkins plugin install]
+image::teamcity_plugin_usage.png[TeamCity plugin usage]


### PR DESCRIPTION
The documentation asked for incorrect filename to be put under `data/plugins/.tools`. This PR fixes this.