### PR TITLE
fix bintray references

### DIFF
--- a/docs/getstarted.adoc
+++ b/docs/getstarted.adoc
@@ -54,7 +54,7 @@ to install a newer version. (link:https://github.com/lukesampson/scoop/wiki/App-
 
 === Manual installation
 
-. Download the latest version as zip archive from link:https://bintray.com/qameta/generic/allure2[bintray].
+. Download the latest version as zip archive from link:http://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/[Maven Central].
 . Unpack the archive to allure-commandline directory.
 . Navigate to *bin* directory.
 . Use *allure.bat* for Windows or *allure* for other Unix platforms.
@@ -64,6 +64,8 @@ to install a newer version. (link:https://github.com/lukesampson/scoop/wiki/App-
 ====
 To run commandline application, Java Runtime Environment must be installed.
 ====
+
+NOTE: Older releases (<= 2.8.0) are available on link:https://bintray.com/qameta/generic/allure2[bintray].
 
 === Check the installation
 Execute `allure --version` in console to make sure that allure is now available:

--- a/docs/reporting/commandline.adoc
+++ b/docs/reporting/commandline.adoc
@@ -31,7 +31,8 @@ After installation you will have allure command available.
 Read more about https://github.com/allure-framework/allure-debian[Allure Debian Package].
 
 === Windows and other Unix
-* Download the latest version as zip archive from link:https://bintray.com/qameta/generic/allure2[bintray].
+* Download the latest version as zip archive from link:http://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/[Maven Central].
+* (older releases, <= 2.8.0) Download the desired version as zip archive from link:https://bintray.com/qameta/generic/allure2[bintray].
 * Unpack the archive to *allure-commandline* directory.
 * Navigate to *bin* directory.
 * Use *allure.bat* for Windows and *allure* for other Unix platforms.

--- a/docs/reporting/gradle.adoc
+++ b/docs/reporting/gradle.adoc
@@ -122,6 +122,8 @@ allure {
     }
 
     downloadLink = 'https://dl.bintray.com/qameta/generic/io/qameta/allure/allure/2.2.1/allure-2.2.1.zip'
+    // Allure >= 2.8.0 is no longer available on Bintray
+    // downloadLink = 'http://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/2.8.1/allure-commandline-2.8.1.zip'
 }
 ----
 
@@ -145,7 +147,8 @@ allure {
  autoconfiguration
 
  - *String* `downloadLink` - custom location of Allure distribution to download from, by default allure is downloaded
- from bintray by specified version and installed into `.allure` folder in the project root.
+ from bintray by specified version and installed into `.allure` folder in the project root. To use Allure >= 2.8.0,
+ download URL must be configured to use Maven Central as Allure is no longer available on Bintray.
 
 == Tasks
 

--- a/docs/reporting/jenkins.adoc
+++ b/docs/reporting/jenkins.adoc
@@ -24,7 +24,9 @@ image::jenkins_plugin_install.jpeg[Install Allure Commandline]
 
 === Downloading and installing Allure from archive
 . Go to the
-link:https://bintray.com/qameta/generic/allure2[Bintray page], click the latest released version, and download the allure-[version].zip file
+link:http://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/[Maven Central page], click the latest released version, and download the allure-commandline-[version].zip file.
+. (for older releases, <= 2.8.0) Go to the
+link:https://bintray.com/qameta/generic/allure2[Bintray page], click the desired version, and download the allure-[version].zip file.
 . Upload downloaded file to any file server. Build agents must have access to the file by url.
 . Open "Global Tool Configuration". and find "Allure Commandline" configuration block.
 +

--- a/docs/reporting/maven.adoc
+++ b/docs/reporting/maven.adoc
@@ -58,22 +58,29 @@ Since 2.6, the plugin constructs a report using Allure which is downloaded from 
 https://dl.bintray.com/qameta/generic/io/qameta/allure/allure[url].
 Allure is extracted and placed into the *.allure* folder created in your project directory.
 
-The default Allure version is *2.0.1*
+The default Allure version is *2.7.0*
 [source, xml, linenums]
 .pom.xml
 ----
 <configuration>
-    <reportVersion>2.0.1</reportVersion>
+    <reportVersion>2.7.0</reportVersion>
 </configuration>
 ----
 
+You can use Allure >= 2.8.0 if you configure both *reportVersion* and *allureDownloadUrl* (see above) accordingly.
 
 You can specify your own url for the download, or you can specify a file path using the system property **allure.download.url**.
+(%s are replaced by *reportVersion* configuration)
 [source, xml, linenums]
 .pom.xml
 ----
 <configuration>
-    <allureDownloadUrl>https://example.com/allure/allure-2.0.1.zip</allureDownloadUrl>
+    <!-- Allure < 2.7.0 (default value): download from Bintray -->
+    <allureDownloadUrl>https://dl.bintray.com/qameta/generic/io/qameta/allure/allure/%s/allure-%s.zip</allureDownloadUrl>
+    <!-- Allure >= 2.8.0: download from Maven Central -->
+    <!-- <allureDownloadUrl>http://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/%s/allure-commandline-%s.zip</allureDownloadUrl> -->
+    <!-- Custom URL -->
+    <!-- <allureDownloadUrl>https://example.com/allure/allure-2.0.1.zip</allureDownloadUrl> -->
 </configuration>
 ----
 

--- a/docs/reporting/teamcity.adoc
+++ b/docs/reporting/teamcity.adoc
@@ -2,7 +2,7 @@
 
 == Installation
 . https://confluence.jetbrains.com/display/TCD10/Installing+Additional+Plugins[Install Allure TeamCity plugin].
-. Download the latest `allure-x.x.zip` from (https://bintray.com/qameta/generic/allure2[latest release]
+. Download the latest `allure-commandline-x.x.zip` from (http://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/[latest release]
 . Copy downloaded file
 to the <https://confluence.jetbrains.com/display/TCD10/TeamCity+Data+Directory[TeamCity Data Directory]>/plugins/.tools directory as `allure-commandline.zip`.
 No server restart needed for this step.


### PR DESCRIPTION
Allure >= 2.8.0 is no longer available from Bintray. Documentation needs
some update to allow users to find new download locations.

This commit tries to rewrite all bintray related fragments, without
modifying documentation's structure:

* getting started: link replaced by Maven Central; [NOTE] added to allow
  users to download old releases
* commandline: see getting started
* gradle: added a commented-out line with an example of a valid
  *downloadLink* for Allure 2.8.1; added comment on *downloadLink*
  config
* maven: updated default configuration documentation and config;
  added a valid commented-out *allureDownloadUrl* for Allure >= 2.8.0;
  added a WARNING for using Allure >= 2.8.0
* jenkins: updated configuration to use a manually downloaded Allure.
* teamcity: update configuration to use a manually downloaded Allure.

refs: #109 and allure-framework/allure2#832