### PR TITLE
Added information about latest versions of Cucumber JVM adapters

### DIFF
--- a/docs/features/configuration.adoc
+++ b/docs/features/configuration.adoc
@@ -1,0 +1,41 @@
+Templates for Issue and Test Management links can be set by system properties:
+
+- `allure.link.issue.pattern`
+
+- `allure.link.tms.pattern`
+
+Default `allure-results` directory location can also be overridden by setting +
+`allure.results.directory` system property
+
+[source, xml, linenums]
+.pom.xml
+----
+<build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.20</version>
+            <configuration>
+                ...
+                <systemPropertyVariables>
+                    <allure.results.directory>${project.build.directory}/allure-results</allure.results.directory>
+                    <allure.link.issue.pattern>https://example.org/browse/{}</allure.link.issue.pattern>
+                    <allure.link.tms.pattern>https://example.org/browse/{}</allure.link.tms.pattern>
+                </systemPropertyVariables>
+            </configuration>
+            ...
+        </plugin>
+    </plugins>
+</build>
+----
+
+Or by placing `allure.properties` file to resources folder: `src/test/resources`
+
+[source, properties, linenums]
+.allure.properties
+ ----
+allure.results.directory=target/allure-results
+allure.link.issue.pattern=https://example.org/browse/{}
+allure.link.tms.pattern=https://example.org/browse/{}
+ ----

--- a/docs/features/java-configuration.adoc
+++ b/docs/features/java-configuration.adoc
@@ -1,11 +1,13 @@
-Templates for Issue and Test Management links can be set by system properties:
+Location of `allure-results` directory, and patterns for `@TmsLink` and `@Issue` links can be set by placing
+`allure.properties` file with following properties to resources directory: `src/test/resources`
 
-- `allure.link.issue.pattern`
+[source, text, linenums]
+.allure.properties
+allure.results.directory=target/allure-results
+allure.link.issue.pattern=https://example.org/browse/{}
+allure.link.tms.pattern=https://example.org/browse/{}
 
-- `allure.link.tms.pattern`
-
-Default `allure-results` directory location can also be overridden by setting +
-`allure.results.directory` system property
+Or by setting system properties in `pom.xml`
 
 [source, xml, linenums]
 .pom.xml
@@ -30,12 +32,4 @@ Default `allure-results` directory location can also be overridden by setting +
 </build>
 ----
 
-Or by placing `allure.properties` file to resources folder: `src/test/resources`
 
-[source, properties, linenums]
-.allure.properties
- ----
-allure.results.directory=target/allure-results
-allure.link.issue.pattern=https://example.org/browse/{}
-allure.link.tms.pattern=https://example.org/browse/{}
- ----

--- a/docs/integration/cucumberjvm.adoc
+++ b/docs/integration/cucumberjvm.adoc
@@ -100,4 +100,4 @@ Allure Cucumber JVM integration uses information extracted from `Feature:` secti
 
 === Configuration
 
-include::../features/configuration.adoc[]
+include::../features/java-configuration.adoc[]

--- a/docs/integration/cucumberjvm.adoc
+++ b/docs/integration/cucumberjvm.adoc
@@ -2,7 +2,7 @@
 
 == Installation
 
-Each major version of Cucumber JVM requires particular version of Allure Cucumber JVM adapter.
+Each major version of Cucumber JVM requires a particular version of Allure Cucumber JVM adapter.
 
 The available latest version of adapters:
 
@@ -12,7 +12,7 @@ The available latest version of adapters:
 - Cucumber JVM 4.x - `allure-cucumber4-jvm` image:https://img.shields.io/maven-central/v/io.qameta.allure/allure-cucumber4-jvm.svg[Allure Cucumber JVM 4.x]
 
 === Maven
-Simply add `allure-cucumber4-jvm` plugin as dependency to your project and add it to CucumberOptions:
+Simply add `allure-cucumber4-jvm` plugin as a dependency to your project and add it to CucumberOptions:
 
 [source, xml, linenums]
 .pom.xml

--- a/docs/integration/cucumberjvm.adoc
+++ b/docs/integration/cucumberjvm.adoc
@@ -2,12 +2,17 @@
 
 == Installation
 
-The available latest version of `allure-cucumber-jvm`:
+Each major version of Cucumber JVM requires particular version of Allure Cucumber JVM adapter.
 
-image::https://img.shields.io/maven-central/v/io.qameta.allure/allure-cucumber-jvm.svg[Allure CucumberJVM]
+The available latest version of adapters:
+
+- Cucumber JVM 1.x - `allure-cucumber-jvm` image:https://img.shields.io/maven-central/v/io.qameta.allure/allure-cucumber-jvm.svg[Allure Cucumber JVM 1.x]
+- Cucumber JVM 2.x - `allure-cucumber2-jvm` image:https://img.shields.io/maven-central/v/io.qameta.allure/allure-cucumber2-jvm.svg[Allure Cucumber JVM 2.x]
+- Cucumber JVM 3.x - `allure-cucumber3-jvm` image:https://img.shields.io/maven-central/v/io.qameta.allure/allure-cucumber3-jvm.svg[Allure Cucumber JVM 3.x]
+- Cucumber JVM 4.x - `allure-cucumber4-jvm` image:https://img.shields.io/maven-central/v/io.qameta.allure/allure-cucumber4-jvm.svg[Allure Cucumber JVM 4.x]
 
 === Maven
-Simply add `allure-cucumber-jvm` plugin as dependency to your project and add it to CucumberOptions:
+Simply add `allure-cucumber4-jvm` plugin as dependency to your project and add it to CucumberOptions:
 
 [source, xml, linenums]
 .pom.xml
@@ -19,7 +24,7 @@ Simply add `allure-cucumber-jvm` plugin as dependency to your project and add it
 <dependencies>
     <dependency>
         <groupId>io.qameta.allure</groupId>
-        <artifactId>allure-cucumber-jvm</artifactId>
+        <artifactId>allure-cucumber4-jvm</artifactId>
         <version>LATEST_VERSION</version>
     </dependency>
 </dependencies>
@@ -33,7 +38,7 @@ Simply add `allure-cucumber-jvm` plugin as dependency to your project and add it
             <configuration>
                 <argLine>
                     -javaagent:"${settings.localRepository}/org/aspectj/aspectjweaver/${aspectj.version}/aspectjweaver-${aspectj.version}.jar"
-                    -Dcucumber.options="--plugin io.qameta.allure.cucumberjvm.AllureCucumberJvm"
+                    -Dcucumber.options="--plugin io.qameta.allure.cucumber4jvm.AllureCucumber4Jvm"
                 </argLine>
             </configuration>
             <dependencies>
@@ -49,10 +54,9 @@ Simply add `allure-cucumber-jvm` plugin as dependency to your project and add it
 ----
 
 Then execute `mvn clean test` goal. After tests executed allure JSON files will be +
-placed in `allure-results` directory by default. It can be overridden by setting `allure.results.directory` +
-system property.
+placed in `allure-results` directory by default.
 
-== Features
+=== Features
 This adapter provides runtime integration allowing conversion of Gherkin dsl features into basic Allure features
 
 === Display Name
@@ -93,3 +97,7 @@ will be marked as failed.
 
 === Behaviours Mapping
 Allure Cucumber JVM integration uses information extracted from `Feature:` section.
+
+=== Configuration
+
+include::../features/configuration.adoc[]


### PR DESCRIPTION
Following PR https://github.com/allure-framework/allure-java/pull/286, adding information about latest version of Cucumber JVM adapters to Docs

+

Added `Configuration` block (`allure-results` and and Issue/TMS link patterns)