### PR TITLE
Fix maven-surefire-plugin version in junit5 pom

### DIFF
--- a/content/frameworks/java/junit5.md
+++ b/content/frameworks/java/junit5.md
@@ -38,7 +38,7 @@ Add the following to your **pom.xml**:
     <plugins>
         <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.21</version>
+                <version>2.21.0</version>
                 <configuration>
                 <testFailureIgnore>false</testFailureIgnore>
                         <argLine>


### PR DESCRIPTION
There is a typo in pom.xml example for JUnit 5 doc: a non-existing version of `maven-surefire-plugin` (2.21, [see all existing versions here](https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin)) is requested. Maven cannot find it and exits with the error:
```
[ERROR] Plugin org.apache.maven.plugins:maven-surefire-plugin:2.21 or one of its dependencies could not be resolved: Could not find artifact org.apache.maven.plugins:maven-surefire-plugin:jar:2.21 in central (https://repo.maven.apache.org/maven2) -> [Help 1]
```

Changed the version to 2.21.0.